### PR TITLE
feat: implement TvText taking arguments for pre-populating the search…

### DIFF
--- a/lua/tv.lua
+++ b/lua/tv.lua
@@ -72,7 +72,7 @@ local function populate_quickfix(items, title)
   end
 end
 
-local function launch_tv_channel(channel, handler, expect_key)
+local function launch_tv_channel(channel, handler, expect_key, prompt_input)
   M.create_win_and_buf(channel)
   local output = {}
 
@@ -86,6 +86,10 @@ local function launch_tv_channel(channel, handler, expect_key)
   end
 
   vim.list_extend(cmd, { channel })
+
+  if prompt_input then
+    vim.list_extend(cmd, { "-i" .. tostring(prompt_input) })
+  end
 
   vim.fn.jobstart(cmd, {
     on_exit = function(_, exit_code)
@@ -288,9 +292,9 @@ M.tv_files = function()
   launch_tv_channel("files", handle_files_output, expect_key)
 end
 
-M.tv_text = function()
+M.tv_text = function(prompt_input)
   local expect_key = convert_keybinding_to_tv_format(M.config.keybindings.text_qf)
-  launch_tv_channel("text", handle_text_output, expect_key)
+  launch_tv_channel("text", handle_text_output, expect_key, prompt_input)
 end
 
 -- Expose for testing

--- a/plugin/tv.lua
+++ b/plugin/tv.lua
@@ -13,10 +13,15 @@ end, {
   desc = "Launch tv for file searching",
 })
 
-vim.api.nvim_create_user_command("TvText", function()
-  require("tv").tv_text()
+vim.api.nvim_create_user_command("TvText", function(opts)
+  if string.len(opts.args) < 1 then
+    require("tv").tv_text()
+  else
+    require("tv").tv_text(tostring(opts.args))
+  end
 end, {
   desc = "Launch tv for text searching",
+  nargs = "*"
 })
 
 vim.api.nvim_create_user_command("Tv", function()
@@ -32,6 +37,10 @@ end, { desc = "TV: Find files" })
 
 vim.keymap.set("n", "<leader><leader>", function()
   require("tv").tv_text()
+end, { desc = "TV: Search text" })
+
+vim.keymap.set("n", "<leader>td", function()
+  require("tv").tv_todo()
 end, { desc = "TV: Search text" })
 
 vim.keymap.set("n", "<leader>tv", function()


### PR DESCRIPTION
This allows TvText to take arguments that are fed into `tv`'s `-i` flag, prepopulating the search prompt. This means the user can just map ```vim.cmd("TvText \'TODO")``` to a keybind of their choice, making for an easy list of TODO lines in a project. This should probably be expanded to a global implementation that also considers TvFiles and potential other channels.