### PR TITLE
Add a dedicated filetype and disable spell checking in search results

### DIFF
--- a/lua/tv/window.lua
+++ b/lua/tv/window.lua
@@ -13,7 +13,9 @@ function M.create(channel)
   local col = (editor_width - tv_width) / 2
 
   local buffer = vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_open_win(buffer, true, {
+  vim.bo[buffer].filetype = "tv"
+
+  local window = vim.api.nvim_open_win(buffer, true, {
     relative = "editor",
     width = tv_width,
     height = tv_height,
@@ -23,6 +25,9 @@ function M.create(channel)
     title = window_config.title,
     title_pos = window_config.title_pos,
   })
+  vim.wo[window].spell = false
+
+  return window
 end
 
 return M


### PR DESCRIPTION
I have spell checking turned on globally, and it was flagging all kinds of words in tv search results. Fix this by adding a `vim.wo[window].spell = false` after creating the window.

Why the filetype `tv`? My logic that if the tv window would've had a dedicated filetype, I could've tweaked this setting via an autocommand. For example, a Telescope window is of filetype `TelescopePrompt`.