### PR TITLE
feat: add layout option to override tv orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Here's a more comprehensive configuration example demonstrating the plugin's cap
       local h = require("tv").handlers
 
       require("tv").setup({
+        layout = "landscape", -- "landscape" (default) or "portrait"
         -- global window appearance (can be overridden per channel)
         window = {
           width = 0.8, -- 80% of editor width
@@ -154,6 +155,7 @@ Here's a more comprehensive configuration example demonstrating the plugin's cap
         channels = {
           -- `files`: fuzzy find files in your project
           files = {
+            layout = "portrait", --- override global setting for this channel
             keybinding = "<C-p>", -- Launch the files channel
             -- what happens when you press a key
             handlers = {

--- a/lua/tv/channels.lua
+++ b/lua/tv/channels.lua
@@ -14,6 +14,11 @@ local function launch_channel(channel, handler_map, prompt_input)
   local channel_config = config.get_channel_config(channel)
   vim.list_extend(cmd, channel_config.args)
 
+  local layout = config.get_layout(channel)
+  if layout then
+    vim.list_extend(cmd, { "--layout", layout })
+  end
+
   if handler_map and type(handler_map) == "table" then
     local expect_keys = {}
     for nvim_key, _ in pairs(handler_map) do

--- a/lua/tv/config.lua
+++ b/lua/tv/config.lua
@@ -9,9 +9,11 @@ local function get_handlers()
 end
 
 local DEFAULT_TV_ARGS = { "--no-remote", "--no-status-bar" }
+local VALID_LAYOUTS = { landscape = true, portrait = true }
 
 M.defaults = {
   tv_binary = "tv",
+  layout = "landscape",
   quickfix = {
     auto_open = true,
   },
@@ -27,7 +29,7 @@ M.defaults = {
   },
   channels = {
     files = {
-      args = { "--no-remote", "--no-status-bar", "--preview-size", "70", "--layout", "portrait" },
+      args = { "--no-remote", "--no-status-bar", "--preview-size", "70" },
       keybinding = nil,
       handlers = {
         ["<CR>"] = function(entries, config)
@@ -39,7 +41,7 @@ M.defaults = {
       },
     },
     text = {
-      args = { "--no-remote", "--no-status-bar", "--preview-size", "70", "--layout", "portrait" },
+      args = { "--no-remote", "--no-status-bar", "--preview-size", "70" },
       keybinding = nil,
       handlers = {
         ["<CR>"] = function(entries, config)
@@ -92,6 +94,17 @@ function M.initialize_channel_defaults()
       M.current.channels[channel_name] = defaults
     end
   end
+end
+
+function M.get_layout(channel)
+  local layout = M.current.layout
+  if channel and M.current.channels[channel] and M.current.channels[channel].layout then
+    layout = M.current.channels[channel].layout
+  end
+  if layout and VALID_LAYOUTS[layout] then
+    return layout
+  end
+  return nil
 end
 
 function M.get_window_config(channel)

--- a/lua/tv/handlers.lua
+++ b/lua/tv/handlers.lua
@@ -4,6 +4,7 @@ local M = {}
 
 ---@class tv.Config
 ---@field tv_binary string
+---@field layout? string
 ---@field quickfix { auto_open: boolean }
 ---@field window { width: number, height: number, border: string, title: string, title_pos: string }
 ---@field global_keybindings { channels: string }
@@ -12,6 +13,7 @@ local M = {}
 ---@class tv.ChannelConfig
 ---@field keybinding? string
 ---@field args? string[]
+---@field layout? string
 ---@field window? { width?: number, height?: number, border?: string, title?: string, title_pos?: string }
 ---@field handlers? table<string, tv.Handler>
 


### PR DESCRIPTION
Thank you for making this amazing neovim plugin. I've migrated most of my workflow to use `tv` and `tv.nvim` and I'd now like to contribute back.

I noticed that `tv.nvim` hardcodes `--layout portrait` in the defaults args for the files and text channels, with no configuration option to change the orientation. I added `layout` as a first-class config field that can be set globally and also overriden per-channel. The resolved config value is then appended as `--layout <value>` when spawning the tv process.